### PR TITLE
WIP: Allow overwriting file extensions of generated JS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ on the client side, and all files of those types belong to a module.
 **Automatic update to index.js**
 
 For `action`, `collection`, `method`, and `publication`, the command automatically
-inserts `import` and `export` statements to the relevant `index.js` file.
+inserts `import` and `export` statements to the relevant `index` file.
 
 ---------------------------------------
 
@@ -129,6 +129,7 @@ customize:
 * templates
 * generateComponentTests (true)
 * generateContainerTests (true)
+* Overwrite extensions for `.js` and `.jsx` files.
 
 You may customize Mantra-CLI by editing `mantra_cli.yaml` on the root directory
 of your project. Please open an issue with suggestions for more customization.
@@ -217,6 +218,16 @@ Generate stories for Kadira Storybooks with generation of a new component.
 
 ```yaml
 storybook: true
+```
+
+### extensions
+Allows overwriting file extensions of generated files.
+Only applied for files which are used solely on the client. This excludes collections, publications and methods.
+Useful when working with React-Native or Typescript projects.
+
+```yaml
+jsxExtension: jsx
+jsExtension: js
 ```
 
 ---------------------------------------

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -10,6 +10,7 @@ import {parseYamlFromFile, checkFileExists, createDir, getFileContent, createFil
 import {getConfig} from '../config_utils';
 import {logger} from '../logger';
 import {generateModule} from '../generators/module';
+import {getWebpackTemplatePath} from '../generators/storybook';
 
 export default function create(appPath, options = {}) {
   if (checkFileExists(`${shelljs.pwd()}/.meteor`)) {
@@ -54,9 +55,9 @@ export default function create(appPath, options = {}) {
   outputFileSync(`${appPath}/mantra_cli.yaml`, yaml.safeDump(config));
 
   createFile(`${templatesPath}/client/configs/context.js`,
-           `${appPath}/client/configs/context.js`);
+           `${appPath}/client/configs/context.${config.jsExtension}`);
   createFile(`${templatesPath}/client/main.js`,
-           `${appPath}/client/main.js`);
+           `${appPath}/client/main.${config.jsExtension}`);
 
   createFile(`${templatesPath}/lib/collections/index.js`,
            `${appPath}/lib/collections/index.js`);
@@ -83,7 +84,7 @@ export default function create(appPath, options = {}) {
     createDir(`${appPath}/.storybook`);
     createFile(`${templatesPath}/.storybook/config.js`,
       `${appPath}/.storybook/config.js`);
-    createFile(`${templatesPath}/.storybook/webpack.config.js`,
+    createFile(getWebpackTemplatePath(templatesPath, config.jsExtension),
       `${appPath}/.storybook/webpack.config.js`);
 
   }

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -10,6 +10,7 @@ import {parseYamlFromFile, checkFileExists, createDir, getFileContent, createFil
 import {getConfig} from '../config_utils';
 import {logger} from '../logger';
 import {generateModule} from '../generators/module';
+import {getWebpackTemplatePath} from '../generators/storybook';
 
 export default function create(appPath, options = {}) {
   if (checkFileExists(`${shelljs.pwd()}/.meteor`)) {
@@ -81,9 +82,9 @@ export default function create(appPath, options = {}) {
   // Generate storybook related files
   if (config.storybook) {
     createDir(`${appPath}/.storybook`);
-    createFile(`${templatesPath}/.storybook/config.${config.jsExtension}`,
-      `${appPath}/.storybook/config.${config.jsExtension}`);
-    createFile(`${templatesPath}/.storybook/webpack.config.js`,
+    createFile(`${templatesPath}/.storybook/config.js`,
+      `${appPath}/.storybook/config.js`);
+    createFile(getWebpackTemplatePath(templatesPath, config.jsExtension),
       `${appPath}/.storybook/webpack.config.js`);
 
   }

--- a/lib/commands/create.js
+++ b/lib/commands/create.js
@@ -54,9 +54,9 @@ export default function create(appPath, options = {}) {
   outputFileSync(`${appPath}/mantra_cli.yaml`, yaml.safeDump(config));
 
   createFile(`${templatesPath}/client/configs/context.js`,
-           `${appPath}/client/configs/context.js`);
+           `${appPath}/client/configs/context.${config.jsExtension}`);
   createFile(`${templatesPath}/client/main.js`,
-           `${appPath}/client/main.js`);
+           `${appPath}/client/main.${config.jsExtension}`);
 
   createFile(`${templatesPath}/lib/collections/index.js`,
            `${appPath}/lib/collections/index.js`);
@@ -81,8 +81,8 @@ export default function create(appPath, options = {}) {
   // Generate storybook related files
   if (config.storybook) {
     createDir(`${appPath}/.storybook`);
-    createFile(`${templatesPath}/.storybook/config.js`,
-      `${appPath}/.storybook/config.js`);
+    createFile(`${templatesPath}/.storybook/config.${config.jsExtension}`,
+      `${appPath}/.storybook/config.${config.jsExtension}`);
     createFile(`${templatesPath}/.storybook/webpack.config.js`,
       `${appPath}/.storybook/webpack.config.js`);
 

--- a/lib/config_utils.js
+++ b/lib/config_utils.js
@@ -10,6 +10,7 @@ export const DEFAULT_CONFIG = {
   modulesPath: 'client/modules',
   snakeCaseFileNames: true,
   jsxExtension: "jsx",
+  jsExtension: "js",
   storiesFolder: ".stories"
 };
 

--- a/lib/generators/action.js
+++ b/lib/generators/action.js
@@ -18,7 +18,7 @@ export function generateAction(name, options, customConfig) {
 
   if (!exists) {
     updateIndexFile({
-      indexFilePath: `./${config.modulesPath}/${moduleName}/actions/index.js`,
+      indexFilePath: `./${config.modulesPath}/${moduleName}/actions/index.${config.jsExtension}`,
       exportBeginning: 'export default {',
       insertImport: `import ${entityName} from './${getFileName(customConfig, entityName)}';`,
       insertExport: `  ${entityName}`,
@@ -37,6 +37,6 @@ export function destroyAction(name, options, customConfig) {
   ensureModuleExists(moduleName, customConfig);
 
   removeFile(getOutputPath(customConfig, 'action', entityName, moduleName));
-  removeFile(getTestOutputPath('action', entityName, moduleName));
-  removeFromIndexFile(`./${config.modulesPath}/${moduleName}/actions/index.js`, entityName, customConfig);
+  removeFile(getTestOutputPath('action', entityName, moduleName, config.jsExtension));
+  removeFromIndexFile(`./${config.modulesPath}/${moduleName}/actions/index.${config.jsExtension}`, entityName, customConfig);
 }

--- a/lib/generators/component.js
+++ b/lib/generators/component.js
@@ -25,11 +25,12 @@ export function generateComponent(name, options, customConfig) {
 export function destroyComponent(name, options, customConfig) {
 
   let [moduleName, entityName] = name.split(':');
+  const config = getConfig(config);
 
   ensureModuleNameProvided(name);
   ensureModuleExists(moduleName, customConfig);
   removeFile(getOutputPath(customConfig, 'component', entityName, moduleName));
   destroyStorybook(name, options, customConfig);
-  removeFile(getTestOutputPath('component', entityName, moduleName));
+  removeFile(getTestOutputPath('component', entityName, moduleName, config.jsExtension));
 
 }

--- a/lib/generators/container.js
+++ b/lib/generators/container.js
@@ -30,11 +30,12 @@ export function generateContainer(name, options, customConfig) {
 
 export function destroyContainer(name, options, customConfig) {
   let [moduleName, entityName] = name.split(':');
+  const config = getConfig(customConfig);
 
   removeFile(getOutputPath(customConfig, 'container', entityName, moduleName));
-  removeFile(getTestOutputPath('container', entityName, moduleName));
+  removeFile(getTestOutputPath('container', entityName, moduleName, config.jsExtension));
   removeFile(getOutputPath(customConfig, 'component', entityName, moduleName));
   destroyStorybook(name, options, customConfig);
-  removeFile(getTestOutputPath('component', entityName, moduleName));
+  removeFile(getTestOutputPath('component', entityName, moduleName, config.jsExtension));
 
 }

--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -1,17 +1,17 @@
 import fs from 'fs';
 import _ from 'lodash';
-import { createDir, createFile, insertToFile, checkFileExists } from '../utils';
-import { removeFile, removeWholeLine } from './utils';
-import { getConfig } from '../config_utils';
-import { logger } from '../logger';
+import {createDir, createFile, insertToFile, checkFileExists} from '../utils';
+import {removeFile, removeWholeLine} from './utils';
+import {getConfig} from '../config_utils';
+import {logger} from '../logger';
 import path from 'path';
-import { outputFileSync } from 'fs-extra';
+import {outputFileSync} from 'fs-extra';
 
 const makeRelative = (from, to) => {
   const relativePath = path.relative(from, to);
   // add ./ if its child
-  if (!_.startsWith(relativePath, ".")) {
-    return "./" + relativePath;
+  if(!_.startsWith(relativePath, ".")) {
+    return "./"+relativePath;
   }
   return relativePath;
 };
@@ -33,11 +33,11 @@ export function generateModule(name, options, customConfig = {}) {
     `${modulePath}/index.${config.jsExtension}`);
   createFile(`${templatesPath}/client/modules/core/routes.tt`,
     `${modulePath}/routes.${config.jsxExtension}`);
-  if (name === 'core') {
+  if(name === 'core') {
     createFile(`${templatesPath}/client/modules/core/components/main_layout.jsx`,
-      `${modulePath}/components/main_layout.${config.jsxExtension}`);
-    createFile(`${templatesPath}/client/modules/core/components/home.jsx`,
-      `${modulePath}/components/home.${config.jsxExtension}`);
+           `${modulePath}/components/main_layout.${config.jsxExtension}`);
+     createFile(`${templatesPath}/client/modules/core/components/home.jsx`,
+            `${modulePath}/components/home.${config.jsxExtension}`);
   }
 
   // Modify client/main.js to import and load the newly generated module
@@ -45,49 +45,49 @@ export function generateModule(name, options, customConfig = {}) {
   const clientMain = `${clientDir}/main.${config.jsExtension}`;
   const modulePathRelative = makeRelative(clientDir, modulePath);
   insertToFile(clientMain,
-    `import ${snakeCaseName}Module from '${modulePathRelative}';`,
-    {
-      or: [
-        {
-          after: {
-            regex: /import .*Module from \'\.\/modules\/.*\';/g,
-            last: true
-          },
-          asNewLine: true
+  `import ${snakeCaseName}Module from '${modulePathRelative}';`,
+  {
+    or: [
+      {
+        after: {
+          regex: /import .*Module from \'\.\/modules\/.*\';/g,
+          last: true
         },
-        {
-          after: {
-            regex: /\/\/ modules/g,
-          },
-          asNewLine: true
-        }
-      ]
-    });
+        asNewLine: true
+      },
+      {
+        after: {
+          regex: /\/\/ modules/g,
+        },
+        asNewLine: true
+      }
+    ]
+  });
 
   insertToFile(clientMain,
-    `app.loadModule(${snakeCaseName}Module);`,
-    {
-      or: [
-        {
-          after: {
-            regex: /app.loadModule\(.*Module\);/g,
-            last: true
-          },
-          asNewLine: true
+  `app.loadModule(${snakeCaseName}Module);`,
+  {
+    or: [
+      {
+        after: {
+          regex: /app.loadModule\(.*Module\);/g,
+          last: true
         },
-        {
-          after: {
-            regex: /\/\/ load modules/g,
-          },
-          asNewLine: true
-        }
-      ]
-    });
+        asNewLine: true
+      },
+      {
+        after: {
+          regex:  /\/\/ load modules/g,
+        },
+        asNewLine: true
+      }
+    ]
+  });
 
   if (config.storybook) {
     const moduleStoriesDir = `${modulePath}/components/${config.storiesFolder}`;
     const moduleStoriesIndex = `${moduleStoriesDir}/index.${config.jsExtension}`;
-    addToStorybookConfig({ storybookConfigFile, moduleStoriesIndex, config });
+    addToStorybookConfig({storybookConfigFile, moduleStoriesIndex, config});
     createDir(moduleStoriesDir);
     createFile(`${templatesPath}/client/modules/core/components/.stories/index.js`,
       moduleStoriesIndex);
@@ -97,18 +97,18 @@ export function generateModule(name, options, customConfig = {}) {
 const storyRequireStatement = storyFile =>
   `require('${path.relative("./.storybook", storyFile)}');`;
 
-function addToStorybookConfig({ storybookConfigFile, moduleStoriesIndex, config }) {
+function addToStorybookConfig({storybookConfigFile, moduleStoriesIndex, config}) {
   const statement = storyRequireStatement(moduleStoriesIndex);
   let tab = _.repeat(' ', config.tabSize);
   // avoid duplicates
-  removeFromStorybookConfig({ storybookConfigFile, moduleStoriesIndex });
-  insertToFile(storybookConfigFile, tab + statement,
-    { after: { regex: /loadStories[^{]*{/g }, asNewLine: true }
+  removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex});
+  insertToFile(storybookConfigFile, tab+statement,
+    {after: {regex: /loadStories[^{]*{/g},asNewLine: true}
   );
 }
 
-function removeFromStorybookConfig({ storybookConfigFile, moduleStoriesIndex }) {
-  let content = fs.readFileSync(storybookConfigFile, { encoding: 'utf-8' });
+function removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex}) {
+  let content = fs.readFileSync(storybookConfigFile, {encoding: 'utf-8'});
   const statement = storyRequireStatement(moduleStoriesIndex);
   content = removeWholeLine(content, statement);
   outputFileSync(storybookConfigFile, content);
@@ -124,14 +124,14 @@ export function destroyModule(name, options, customConfig) {
   const storybookConfigFile = `.storybook/config.${config.jsExtension}`;
   if (checkFileExists(storybookConfigFile)) {
     const moduleStoriesIndex = `${modulePath}/components/${config.storiesFolder}/index.${config.jsExtension}`;
-    removeFromStorybookConfig({ storybookConfigFile, moduleStoriesIndex });
+    removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex});
   }
   const clientDir = "./client";
   const clientMain = `${clientDir}/main.${config.jsExtension}`;
   const modulePathRelative = makeRelative(clientDir, modulePath);
 
   logger.update(clientMain);
-  let content = fs.readFileSync(clientMain, { encoding: 'utf-8' });
+  let content = fs.readFileSync(clientMain, {encoding: 'utf-8'});
   content = removeWholeLine(content,
     `import ${snakeCaseName}Module from '${modulePathRelative}';`);
   content = removeWholeLine(content, `app.loadModule(${snakeCaseName}Module);`);

--- a/lib/generators/module.js
+++ b/lib/generators/module.js
@@ -1,24 +1,24 @@
 import fs from 'fs';
 import _ from 'lodash';
-import {createDir, createFile, insertToFile, checkFileExists} from '../utils';
-import {removeFile, removeWholeLine} from './utils';
-import {getConfig} from '../config_utils';
-import {logger} from '../logger';
+import { createDir, createFile, insertToFile, checkFileExists } from '../utils';
+import { removeFile, removeWholeLine } from './utils';
+import { getConfig } from '../config_utils';
+import { logger } from '../logger';
 import path from 'path';
-import {outputFileSync} from 'fs-extra';
+import { outputFileSync } from 'fs-extra';
 
 const makeRelative = (from, to) => {
   const relativePath = path.relative(from, to);
   // add ./ if its child
-  if(!_.startsWith(relativePath, ".")) {
-    return "./"+relativePath;
+  if (!_.startsWith(relativePath, ".")) {
+    return "./" + relativePath;
   }
   return relativePath;
 };
 export function generateModule(name, options, customConfig = {}) {
   const config = getConfig(customConfig);
   let snakeCaseName = _.snakeCase(name);
-  const storybookConfigFile = `.storybook/config.js`;
+  const storybookConfigFile = `.storybook/config.${config.jsExtension}`;
   const modulePath = `./${config.modulesPath}/${snakeCaseName}`;
 
   const templatesPath = `${__dirname}/../../templates`;
@@ -28,66 +28,66 @@ export function generateModule(name, options, customConfig = {}) {
   createDir(`${modulePath}/configs`);
   createDir(`${modulePath}/libs`);
   createFile(`${templatesPath}/client/modules/core/actions/index.js`,
-    `${modulePath}/actions/index.js`);
+    `${modulePath}/actions/index.${config.jsExtension}`);
   createFile(`${templatesPath}/client/modules/core/index.js`,
-    `${modulePath}/index.js`);
+    `${modulePath}/index.${config.jsExtension}`);
   createFile(`${templatesPath}/client/modules/core/routes.tt`,
     `${modulePath}/routes.${config.jsxExtension}`);
-  if(name === 'core') {
-    createFile(`${templatesPath}/client/modules/core/components/main_layout.${config.jsxExtension}`,
-           `${modulePath}/components/main_layout.${config.jsxExtension}`);
-     createFile(`${templatesPath}/client/modules/core/components/home.${config.jsxExtension}`,
-            `${modulePath}/components/home.${config.jsxExtension}`);
+  if (name === 'core') {
+    createFile(`${templatesPath}/client/modules/core/components/main_layout.jsx`,
+      `${modulePath}/components/main_layout.${config.jsxExtension}`);
+    createFile(`${templatesPath}/client/modules/core/components/home.jsx`,
+      `${modulePath}/components/home.${config.jsxExtension}`);
   }
 
   // Modify client/main.js to import and load the newly generated module
   const clientDir = "./client";
-  const clientMain = `${clientDir}/main.js`;
+  const clientMain = `${clientDir}/main.${config.jsExtension}`;
   const modulePathRelative = makeRelative(clientDir, modulePath);
   insertToFile(clientMain,
-  `import ${snakeCaseName}Module from '${modulePathRelative}';`,
-  {
-    or: [
-      {
-        after: {
-          regex: /import .*Module from \'\.\/modules\/.*\';/g,
-          last: true
+    `import ${snakeCaseName}Module from '${modulePathRelative}';`,
+    {
+      or: [
+        {
+          after: {
+            regex: /import .*Module from \'\.\/modules\/.*\';/g,
+            last: true
+          },
+          asNewLine: true
         },
-        asNewLine: true
-      },
-      {
-        after: {
-          regex: /\/\/ modules/g,
-        },
-        asNewLine: true
-      }
-    ]
-  });
+        {
+          after: {
+            regex: /\/\/ modules/g,
+          },
+          asNewLine: true
+        }
+      ]
+    });
 
   insertToFile(clientMain,
-  `app.loadModule(${snakeCaseName}Module);`,
-  {
-    or: [
-      {
-        after: {
-          regex: /app.loadModule\(.*Module\);/g,
-          last: true
+    `app.loadModule(${snakeCaseName}Module);`,
+    {
+      or: [
+        {
+          after: {
+            regex: /app.loadModule\(.*Module\);/g,
+            last: true
+          },
+          asNewLine: true
         },
-        asNewLine: true
-      },
-      {
-        after: {
-          regex:  /\/\/ load modules/g,
-        },
-        asNewLine: true
-      }
-    ]
-  });
+        {
+          after: {
+            regex: /\/\/ load modules/g,
+          },
+          asNewLine: true
+        }
+      ]
+    });
 
   if (config.storybook) {
     const moduleStoriesDir = `${modulePath}/components/${config.storiesFolder}`;
-    const moduleStoriesIndex = `${moduleStoriesDir}/index.js`;
-    addToStorybookConfig({storybookConfigFile, moduleStoriesIndex, config});
+    const moduleStoriesIndex = `${moduleStoriesDir}/index.${config.jsExtension}`;
+    addToStorybookConfig({ storybookConfigFile, moduleStoriesIndex, config });
     createDir(moduleStoriesDir);
     createFile(`${templatesPath}/client/modules/core/components/.stories/index.js`,
       moduleStoriesIndex);
@@ -97,18 +97,18 @@ export function generateModule(name, options, customConfig = {}) {
 const storyRequireStatement = storyFile =>
   `require('${path.relative("./.storybook", storyFile)}');`;
 
-function addToStorybookConfig({storybookConfigFile, moduleStoriesIndex, config}) {
+function addToStorybookConfig({ storybookConfigFile, moduleStoriesIndex, config }) {
   const statement = storyRequireStatement(moduleStoriesIndex);
   let tab = _.repeat(' ', config.tabSize);
   // avoid duplicates
-  removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex});
-  insertToFile(storybookConfigFile, tab+statement,
-    {after: {regex: /loadStories[^{]*{/g},asNewLine: true}
+  removeFromStorybookConfig({ storybookConfigFile, moduleStoriesIndex });
+  insertToFile(storybookConfigFile, tab + statement,
+    { after: { regex: /loadStories[^{]*{/g }, asNewLine: true }
   );
 }
 
-function removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex}) {
-  let content = fs.readFileSync(storybookConfigFile, {encoding: 'utf-8'});
+function removeFromStorybookConfig({ storybookConfigFile, moduleStoriesIndex }) {
+  let content = fs.readFileSync(storybookConfigFile, { encoding: 'utf-8' });
   const statement = storyRequireStatement(moduleStoriesIndex);
   content = removeWholeLine(content, statement);
   outputFileSync(storybookConfigFile, content);
@@ -121,17 +121,17 @@ export function destroyModule(name, options, customConfig) {
   const modulePath = `./${config.modulesPath}/${snakeCaseName}`;
   removeFile(modulePath);
 
-  const storybookConfigFile = `.storybook/config.js`;
+  const storybookConfigFile = `.storybook/config.${config.jsExtension}`;
   if (checkFileExists(storybookConfigFile)) {
-    const moduleStoriesIndex = `${modulePath}/components/${config.storiesFolder}/index.js`;
-    removeFromStorybookConfig({storybookConfigFile, moduleStoriesIndex});
+    const moduleStoriesIndex = `${modulePath}/components/${config.storiesFolder}/index.${config.jsExtension}`;
+    removeFromStorybookConfig({ storybookConfigFile, moduleStoriesIndex });
   }
   const clientDir = "./client";
-  const clientMain = `${clientDir}/main.js`;
+  const clientMain = `${clientDir}/main.${config.jsExtension}`;
   const modulePathRelative = makeRelative(clientDir, modulePath);
 
   logger.update(clientMain);
-  let content = fs.readFileSync(clientMain, {encoding: 'utf-8'});
+  let content = fs.readFileSync(clientMain, { encoding: 'utf-8' });
   content = removeWholeLine(content,
     `import ${snakeCaseName}Module from '${modulePathRelative}';`);
   content = removeWholeLine(content, `app.loadModule(${snakeCaseName}Module);`);

--- a/lib/generators/storybook.js
+++ b/lib/generators/storybook.js
@@ -5,6 +5,14 @@ import {
   getFileName
 } from './utils';
 import {getConfig} from '../config_utils';
+import { checkFileExists } from '../utils';
+
+export function getWebpackTemplatePath(templatesPath, jsExtension) {
+  const getConfigPath = ext => `${templatesPath}/.storybook/webpack.config.${ext}`;
+  const customExtConfigPath = getConfigPath(jsExtension);
+
+  return checkFileExists(customExtConfigPath) ? customExtConfigPath : getConfigPath('js');
+}
 
 export function generateStorybook(name, options, customConfig = {}) {
   let [moduleName, entityName] = name.split(':');
@@ -17,7 +25,7 @@ export function generateStorybook(name, options, customConfig = {}) {
 
   if (!exists) {
     updateIndexFile({
-      indexFilePath: `${modulePath}/components/${config.storiesFolder}/index.js`,
+      indexFilePath: `${modulePath}/components/${config.storiesFolder}/index.${config.jsExtension}`,
       insertImport: `import './${getFileName(customConfig, entityName)}';`,
       omitExport: true
     });
@@ -33,5 +41,5 @@ export function destroyStorybook(name, options, customConfig = {}) {
   ensureModuleExists(moduleName, customConfig);
   const storyFile = getOutputPath(customConfig, 'storybook', entityName, moduleName);
   removeFile(storyFile);
-  removeFromIndexFile(`./${modulePath}/components/${config.storiesFolder}/index.js`, null, customConfig);
+  removeFromIndexFile(`./${modulePath}/components/${config.storiesFolder}/index.${config.jsExtension}`, null, customConfig);
 }

--- a/lib/generators/storybook.js
+++ b/lib/generators/storybook.js
@@ -5,6 +5,14 @@ import {
   getFileName
 } from './utils';
 import {getConfig} from '../config_utils';
+import { checkFileExists } from '../utils';
+
+export function getWebpackTemplatePath(templatesPath, jsExtension) {
+  const getConfigPath = ext => `${templatesPath}/.storybook/webpack.config.${ext}`;
+  const customExtConfigPath = getConfigPath(jsExtension);
+
+  return checkFileExists(customExtConfigPath) ? customExtConfigPath : getConfigPath('js');
+}
 
 export function generateStorybook(name, options, customConfig = {}) {
   let [moduleName, entityName] = name.split(':');

--- a/lib/generators/storybook.js
+++ b/lib/generators/storybook.js
@@ -17,7 +17,7 @@ export function generateStorybook(name, options, customConfig = {}) {
 
   if (!exists) {
     updateIndexFile({
-      indexFilePath: `${modulePath}/components/${config.storiesFolder}/index.js`,
+      indexFilePath: `${modulePath}/components/${config.storiesFolder}/index.${config.jsExtension}`,
       insertImport: `import './${getFileName(customConfig, entityName)}';`,
       omitExport: true
     });
@@ -33,5 +33,5 @@ export function destroyStorybook(name, options, customConfig = {}) {
   ensureModuleExists(moduleName, customConfig);
   const storyFile = getOutputPath(customConfig, 'storybook', entityName, moduleName);
   removeFile(storyFile);
-  removeFromIndexFile(`./${modulePath}/components/${config.storiesFolder}/index.js`, null, customConfig);
+  removeFromIndexFile(`./${modulePath}/components/${config.storiesFolder}/index.${config.jsExtension}`, null, customConfig);
 }

--- a/lib/generators/storybook.js
+++ b/lib/generators/storybook.js
@@ -5,6 +5,14 @@ import {
   getFileName
 } from './utils';
 import {getConfig} from '../config_utils';
+import { checkFileExists } from '../utils';
+
+export function getWebpackTemplatePath(templatesPath, jsExtension) {
+  const getConfigPath = ext => `${templatesPath}/.storybook/webpack.config.${ext}`;
+  const customExtConfigPath = configPath(jsExtension);
+
+  return checkFileExists(customExtConfigPath) ? customExtConfigPath : configPath('js');
+}
 
 export function generateStorybook(name, options, customConfig = {}) {
   let [moduleName, entityName] = name.split(':');

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -23,14 +23,14 @@ import {getConfig} from '../config_utils';
 export function getOutputPath(customConfig, type, entityName, moduleName) {
   const config = getConfig(customConfig);
   const extensionMap = {
-    action: 'js',
+    action: config.jsExtension,
     component: config.jsxExtension,
-    configs: 'js',
-    container: 'js',
+    configs: config.jsExtension,
+    container: config.jsExtension,
     collection: 'js',
     method: 'js',
     publication: 'js',
-    storybook: 'js'
+    storybook: config.jsExtension
   };
   let extension = extensionMap[type];
   let outputFileName = getFileName(customConfig, entityName, extension);
@@ -68,8 +68,8 @@ export function getFileName(customConfig, entityName, extension = null) {
  *        be generated
  * @return String - the output path relative to the app root
  */
-export function getTestOutputPath(type, entityName, moduleName) {
-  let outputFileName = `${_.snakeCase(entityName)}.js`;
+export function getTestOutputPath(type, entityName, moduleName, jsExtension) {
+  let outputFileName = `${_.snakeCase(entityName)}.${jsExtension}`;
   return `./client/modules/${moduleName}/${type}s/tests/${outputFileName}`;
 }
 
@@ -208,7 +208,7 @@ export function getTemplateVaraibles(type, moduleName, entityName, options = {},
   } else if (type === 'method') {
     return {
       collectionName: pascalCase(entityName),
-      methodFileName: _getFileName(customConfig, entityName)
+      methodFileName: getFileName(customConfig, entityName)
     };
   } else if (type === 'publication') {
     return {
@@ -433,7 +433,7 @@ export function _generate(type, moduleName, entityName, options, customConfig) {
 
 export function _generateTest(type, moduleName, entityName, config) {
   let templateContent = readTemplateContent(type, {testTemplate: true}, config);
-  let outputPath = getTestOutputPath(type, entityName, moduleName);
+  let outputPath = getTestOutputPath(type, entityName, moduleName, config.jsExtension);
   let templateVariables = getTestTemplateVaraibles(type, moduleName, entityName, config);
   let component = _.template(templateContent)(templateVariables);
 

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -23,14 +23,14 @@ import {getConfig} from '../config_utils';
 export function getOutputPath(customConfig, type, entityName, moduleName) {
   const config = getConfig(customConfig);
   const extensionMap = {
-    action: 'js',
+    action: config.jsExtension,
     component: config.jsxExtension,
-    configs: 'js',
-    container: 'js',
+    configs: config.jsExtension,
+    container: config.jsExtension,
     collection: 'js',
     method: 'js',
     publication: 'js',
-    storybook: 'js'
+    storybook: config.jsxExtension
   };
   let extension = extensionMap[type];
   let outputFileName = getFileName(customConfig, entityName, extension);
@@ -68,8 +68,8 @@ export function getFileName(customConfig, entityName, extension = null) {
  *        be generated
  * @return String - the output path relative to the app root
  */
-export function getTestOutputPath(type, entityName, moduleName) {
-  let outputFileName = `${_.snakeCase(entityName)}.js`;
+export function getTestOutputPath(type, entityName, moduleName, jsExtension) {
+  let outputFileName = `${_.snakeCase(entityName)}.${jsExtension}`;
   return `./client/modules/${moduleName}/${type}s/tests/${outputFileName}`;
 }
 
@@ -208,7 +208,7 @@ export function getTemplateVaraibles(type, moduleName, entityName, options = {},
   } else if (type === 'method') {
     return {
       collectionName: pascalCase(entityName),
-      methodFileName: _getFileName(customConfig, entityName)
+      methodFileName: getFileName(customConfig, entityName)
     };
   } else if (type === 'publication') {
     return {
@@ -433,7 +433,7 @@ export function _generate(type, moduleName, entityName, options, customConfig) {
 
 export function _generateTest(type, moduleName, entityName, config) {
   let templateContent = readTemplateContent(type, {testTemplate: true}, config);
-  let outputPath = getTestOutputPath(type, entityName, moduleName);
+  let outputPath = getTestOutputPath(type, entityName, moduleName, config.jsExtension);
   let templateVariables = getTestTemplateVaraibles(type, moduleName, entityName, config);
   let component = _.template(templateContent)(templateVariables);
 

--- a/lib/generators/utils.js
+++ b/lib/generators/utils.js
@@ -30,7 +30,7 @@ export function getOutputPath(customConfig, type, entityName, moduleName) {
     collection: 'js',
     method: 'js',
     publication: 'js',
-    storybook: config.jsExtension
+    storybook: config.jsxExtension
   };
   let extension = extensionMap[type];
   let outputFileName = getFileName(customConfig, entityName, extension);

--- a/templates/.storybook/webpack.config.ts
+++ b/templates/.storybook/webpack.config.ts
@@ -1,0 +1,18 @@
+const path = require('path');
+const include = path.resolve(__dirname, '../');
+
+module.exports = {
+  resolve: {
+    extensions: ['.webpack.js', '.web.js', '.ts', '.tsx', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+        include,
+      }
+    ],
+  }
+};

--- a/test/commands/generate_test.js
+++ b/test/commands/generate_test.js
@@ -201,7 +201,7 @@ describe('core.components.comment_list', () => {
 
     it("generates storybook if configured", function() {
       generate('container', 'core:commentList', {}, { storybook: true });
-      expect(checkFileOrDirExists('./client/modules/core/components/.stories/comment_list.js')).to.equal(true);
+      expect(checkFileOrDirExists('./client/modules/core/components/.stories/comment_list.jsx')).to.equal(true);
     });
   });
 
@@ -283,7 +283,7 @@ describe('core.components.header_menu', () => {
 
     it("generates storybook if configured", function() {
       generate('component', 'core:commentList', {}, { storybook: true });
-      expect(checkFileOrDirExists('./client/modules/core/components/.stories/comment_list.js')).to.equal(true);
+      expect(checkFileOrDirExists('./client/modules/core/components/.stories/comment_list.jsx')).to.equal(true);
     });
   });
 

--- a/test/generators/utils_test.js
+++ b/test/generators/utils_test.js
@@ -116,7 +116,7 @@ describe("getOutputPath", function() {
 
   it("returns a correct output path for a storybook", function() {
     let result = utils.getOutputPath(customConfig, 'storybook', 'user_list', 'core');
-    expect(result).to.equal('./client/modules/core/components/.stories/user_list.js');
+    expect(result).to.equal('./client/modules/core/components/.stories/user_list.jsx');
   });
   describe("with custom modules path", function() {
     const customConfig = {modulesPath: "foo/bar/mantra/modules"};
@@ -137,7 +137,7 @@ describe("getOutputPath", function() {
 
     it("returns a correct output path for a storybook", function() {
       let result = utils.getOutputPath(customConfig, 'storybook', 'user_list', 'core');
-      expect(result).to.equal('./foo/bar/mantra/modules/core/components/.stories/user_list.js');
+      expect(result).to.equal('./foo/bar/mantra/modules/core/components/.stories/user_list.jsx');
     });
   });
 });


### PR DESCRIPTION
This PR allows overwriting file extensions of generated `.js` files using the configuration property `jsExtension` in `mantra_cli.yaml`.
This allows, among other scenarios,  generating typescript files using `mantra g`.

This PR only applies the `jsExtension` property for files which are used solely on the client. This excludes files of collections, publications and methods which are always generated as `.js` files.

Regarding templates, this PR always uses the original `.js` templates, disregarding the provided `jsExtension` setting.

Additionally, this PR contains documentation for the new features and features implemented in #122.

* [x] Allow different storybook webpack config templates for different file extensions.
* [ ] Squash commits properly.